### PR TITLE
feat: Added option to pass desired image encoding to image_conversion_node

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ An example of Stella-VSLAM running on stitched images is shown below:
 In **Terminal 2**, launch the `image_conversion_node` if the bag stores images as `CompressedImage`:
 
 ```
-ros2 run challenge_tools_ros image_conversion_node.py /cam0/image_raw/compressed /camera/image_raw
+ros2 run challenge_tools_ros image_conversion_node.py /cam0/image_raw/compressed /camera/image_raw mono8
 ```
 
 Here, `/cam0/image_raw/compressed` is the compressed image topic in the bag, and `/camera/image_raw` is the image topic that Stella-VSLAM subscribes to. 

--- a/launch/run_stella_vslam.launch.py
+++ b/launch/run_stella_vslam.launch.py
@@ -1,10 +1,11 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from launch.conditions import IfCondition
-from ament_index_python.packages import get_package_share_directory
-import os
 
 
 def generate_launch_description():
@@ -46,6 +47,7 @@ def generate_launch_description():
         arguments=[
             "/cam0/image_raw/compressed",
             "/camera/image_raw",
+            "mono8"
         ],
         condition=IfCondition(LaunchConfiguration("image_conversion"))
     )


### PR DESCRIPTION
The Stella-VSLAM Example described in the README was stuck at "State: Initializing". This is due to the `fisheye.yaml` using the monocular configuration as mentioned in the README. The image conversion step below though doesn't convert the image to grayscale `ros2 run challenge_tools_ros image_conversion_node.py /cam0/image_raw/compressed /camera/image_raw`.

This PR would add the option to pass a desired image encoding to `image_conversion_node.py` and add this option to the example from the README so it runs out of the box.

Test with ROS 2 Humble (Ubuntu 22.04).